### PR TITLE
Update ambiguity definition if no start or stop

### DIFF
--- a/pyscripts/hrp2_correctedpath.py
+++ b/pyscripts/hrp2_correctedpath.py
@@ -47,6 +47,7 @@ for name in files:
            stop_len = contents.index("CLRH")
        except:
            all_dna = 0
+		ambiguity = "NA"
        else:
            all_dna = len(contents[start_len : (stop_len + 4)]) - 7
            if "X" in contents[start_len : stop_len] :


### PR DESCRIPTION
Included a definition for ambiguity variable in the case of start "VDD" and stop "CLRH" not being present in the data to avoid the script failing for negative samples --> ambiguity = "NA"